### PR TITLE
[Release]: add readiness support if postgresql enabled

### DIFF
--- a/charts/confluence-server/Chart.yaml
+++ b/charts/confluence-server/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.6
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/confluence-server/templates/_helpers.tpl
+++ b/charts/confluence-server/templates/_helpers.tpl
@@ -85,6 +85,17 @@ Create a default fully qualified app name for the postgres requirement.
 {{- end -}}
 
 {{/*
+Return true if initContainers are needed
+*/}}
+{{- define "confluence-server.createInitContainer" -}}
+{{- if .Values.postgresql.enabled -}}
+    {{- true -}}
+{{- else if .Values.caCerts }}
+    {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Renders a value that contains template.
 Usage:
 {{ include "confluence-server.tplValue" ( dict "value" .Values.path.to.the.Value "context" $) }}

--- a/charts/confluence-server/templates/deployment.yaml
+++ b/charts/confluence-server/templates/deployment.yaml
@@ -20,8 +20,18 @@ spec:
         {{- . | toYaml | trim | nindent 8 }}
       {{- end }}
     spec:
-      {{- if .Values.caCerts }}
+      {{- if (include "confluence-server.createInitContainer" .) }}
       initContainers:
+        {{- if .Values.postgresql.enabled }}
+        - name: init-postgres
+          image: postgres:9.6.11-alpine
+          imagePullPolicy: IfNotPresent
+          command: [
+            "sh",
+            "-c",
+            "until pg_isready -h {{ .Values.postgresql.fullnameOverride }} -p 5432 ; do echo waiting for {{ .Values.postgresql.fullnameOverride }}; sleep 5; done;"]
+        {{- end }}
+        {{- if .Values.caCerts }}
         - name: ca-certs
           image: adoptopenjdk:11-jdk-hotspot
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -44,6 +54,7 @@ spec:
           env:
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
+        {{- end }}
       {{- end }}
     {{- with .Values.image.pullSecrets }}
       imagePullSecrets:

--- a/charts/crowd/Chart.yaml
+++ b/charts/crowd/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.2
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/crowd/templates/_helpers.tpl
+++ b/charts/crowd/templates/_helpers.tpl
@@ -78,6 +78,17 @@ Create a default fully qualified app name for the postgres requirement.
 {{- end -}}
 
 {{/*
+Return true if initContainers are needed
+*/}}
+{{- define "crowd.createInitContainer" -}}
+{{- if .Values.postgresql.enabled -}}
+    {{- true -}}
+{{- else if .Values.caCerts }}
+    {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Renders a value that contains template.
 Usage:
 {{ include "crowd.tplValue" ( dict "value" .Values.path.to.the.Value "context" $) }}

--- a/charts/crowd/templates/deployment.yaml
+++ b/charts/crowd/templates/deployment.yaml
@@ -20,8 +20,18 @@ spec:
         {{- . | toYaml | trim | nindent 8 }}
       {{- end }}
     spec:
-      {{- if .Values.caCerts }}
+      {{- if (include "crowd.createInitContainer" .) }}
       initContainers:
+        {{- if .Values.postgresql.enabled }}
+        - name: init-postgres
+          image: postgres:9.6.11-alpine
+          imagePullPolicy: IfNotPresent
+          command: [
+            "sh",
+            "-c",
+            "until pg_isready -h {{ .Values.postgresql.fullnameOverride }} -p 5432 ; do echo waiting for {{ .Values.postgresql.fullnameOverride }}; sleep 5; done;"]
+        {{- end }}
+        {{- if .Values.caCerts }}
         - name: ca-certs
           image: adoptopenjdk:11-jdk-hotspot
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -44,6 +54,7 @@ spec:
           env:
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
+        {{- end }}
       {{- end }}
     {{- with .Values.image.pullSecrets }}
       imagePullSecrets:

--- a/charts/jira-software/Chart.yaml
+++ b/charts/jira-software/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.7
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/jira-software/templates/_helpers.tpl
+++ b/charts/jira-software/templates/_helpers.tpl
@@ -78,6 +78,17 @@ Create a default fully qualified app name for the postgres requirement.
 {{- end -}}
 
 {{/*
+Return true if initContainers are needed
+*/}}
+{{- define "jira-software.createInitContainer" -}}
+{{- if .Values.postgresql.enabled -}}
+    {{- true -}}
+{{- else if .Values.caCerts }}
+    {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Renders a value that contains template.
 Usage:
 {{ include "jira-software.tplValue" ( dict "value" .Values.path.to.the.Value "context" $) }}

--- a/charts/jira-software/templates/deployment.yaml
+++ b/charts/jira-software/templates/deployment.yaml
@@ -20,8 +20,18 @@ spec:
         {{- . | toYaml | trim | nindent 8 }}
       {{- end }}
     spec:
-      {{- if .Values.caCerts }}
+      {{- if (include "jira-software.createInitContainer" .) }}
       initContainers:
+        {{- if .Values.postgresql.enabled }}
+        - name: init-postgres
+          image: postgres:9.6.11-alpine
+          imagePullPolicy: IfNotPresent
+          command: [
+            "sh",
+            "-c",
+            "until pg_isready -h {{ .Values.postgresql.fullnameOverride }} -p 5432 ; do echo waiting for {{ .Values.postgresql.fullnameOverride }}; sleep 5; done;"]
+        {{- end }}
+        {{- if .Values.caCerts }}
         - name: ca-certs
           image: adoptopenjdk:11-jdk-hotspot
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -44,6 +54,7 @@ spec:
           env:
             {{- . | toYaml | trim | nindent 12 }}
           {{- end }}
+        {{- end }}
       {{- end }}
     {{- with .Values.image.pullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
If `postgresql.enabled` is set to true then an init container will test the Database readiness before changing the deployment status to ready.