### PR TITLE
Allow the database connection protocol to be overridden

### DIFF
--- a/charts/confluence-server/Chart.yaml
+++ b/charts/confluence-server/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.4
+version: 2.0.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/confluence-server/README.md
+++ b/charts/confluence-server/README.md
@@ -354,7 +354,7 @@ $ helm upgrade --install my-release \
 
 ## <a name="values_values-prod-diff"></a>Difference between values and values-production
 
-Chart Version 2.0.4
+Chart Version 2.0.5
 ```diff
 --- confluence-server/values.yaml
 +++ confluence-server/values-production.yaml

--- a/charts/confluence-server/README.md
+++ b/charts/confluence-server/README.md
@@ -163,6 +163,7 @@ By default a PostgreSQL will be deployed and a user and a database will be creat
 | `databaseConnection.lang`                | Encoding used for lc_ctype and lc_collate in case the database needs to be created       | `C`                          |
 | `databaseConnection.port`                | Confluence database server port                                                          | `5432`                       |
 | `databaseConnection.type`                | Confluence database server type                                                          | `postgresql`                 |
+| `databaseConnection.protocol`            | Confluence database JDBC connection protocol                                             | `nil`                        |
 | `databaseDrop.enabled`                   | Enable database removal. See [remove existing database](#remove-existing-database)       | `false`                      |
 | `databaseDrop.dropIt`                    | Confirm database removal if set to `yes`                                                 | `no`                         |
 

--- a/charts/confluence-server/templates/configmap.yaml
+++ b/charts/confluence-server/templates/configmap.yaml
@@ -8,7 +8,11 @@ data:
   {{- range $key, $val := .Values.envVars }}
   {{ $key }}: {{ $val | quote }}
   {{- end }}
+  {{- if .Values.databaseConnection.protocol }}
+  ATL_JDBC_URL: "{{ .Values.databaseConnection.protocol }}://{{ .Values.databaseConnection.host }}:{{ .Values.databaseConnection.port }}/{{ .Values.databaseConnection.database }}"
+  {{- else }}
   ATL_JDBC_URL: "jdbc:{{ .Values.databaseConnection.type }}://{{ .Values.databaseConnection.host }}:{{ .Values.databaseConnection.port }}/{{ .Values.databaseConnection.database }}"
+  {{- end }}
   ATL_JDBC_USER: "{{ .Values.databaseConnection.user }}"
   ATL_DB_TYPE: "{{ .Values.databaseConnection.type }}"
   {{- if .Values.ingress.enabled }}

--- a/charts/confluence-server/values.yaml
+++ b/charts/confluence-server/values.yaml
@@ -275,6 +275,9 @@ databaseConnection:
   ## Database Type
   type: postgresql
 
+  ## Override protocol in JDBC URL
+  #protocol: jdbc:postgresql
+
 ## DB DROP, use with caution!
 ## If postgresql.enabled is set to true and database exists, it will drop the db before creating a new one
 ## (see db-helper ConfigMap)

--- a/charts/confluence-server/values.yaml
+++ b/charts/confluence-server/values.yaml
@@ -276,7 +276,7 @@ databaseConnection:
   type: postgresql
 
   ## Override protocol in JDBC URL
-  #protocol: jdbc:postgresql
+  # protocol: jdbc:postgresql
 
 ## DB DROP, use with caution!
 ## If postgresql.enabled is set to true and database exists, it will drop the db before creating a new one


### PR DESCRIPTION
We're trying to use this chart to connect our Confluence installation to a MS SQL database, and encountered the following issue :

- the official Atlassian image expects `ATL_DB_TYPE` to be set to `mssql` (see `/opt/atlassian/etc/confluence.cfg.xml.j2`)
- but the `ATL_JDBC_URL` should start with `jdbc:sqlserver` to be JDBC-compliant

This PR solves this issue by allowing an override of the protocol used in the JDBC URL.