### PR TITLE
Allow override of JDBC URL

### DIFF
--- a/charts/confluence-server/Chart.yaml
+++ b/charts/confluence-server/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.4
+version: 2.0.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/confluence-server/README.md
+++ b/charts/confluence-server/README.md
@@ -163,6 +163,7 @@ By default a PostgreSQL will be deployed and a user and a database will be creat
 | `databaseConnection.lang`                | Encoding used for lc_ctype and lc_collate in case the database needs to be created       | `C`                          |
 | `databaseConnection.port`                | Confluence database server port                                                          | `5432`                       |
 | `databaseConnection.type`                | Confluence database server type                                                          | `postgresql`                 |
+| `databaseConnection.jdbcUrl`             | Override JDBC URL                                                                        | `nil`      `                 |
 | `databaseDrop.enabled`                   | Enable database removal. See [remove existing database](#remove-existing-database)       | `false`                      |
 | `databaseDrop.dropIt`                    | Confirm database removal if set to `yes`                                                 | `no`                         |
 
@@ -353,7 +354,7 @@ $ helm upgrade --install my-release \
 
 ## <a name="values_values-prod-diff"></a>Difference between values and values-production
 
-Chart Version 2.0.4
+Chart Version 2.0.5
 ```diff
 --- confluence-server/values.yaml
 +++ confluence-server/values-production.yaml

--- a/charts/confluence-server/templates/configmap.yaml
+++ b/charts/confluence-server/templates/configmap.yaml
@@ -8,7 +8,11 @@ data:
   {{- range $key, $val := .Values.envVars }}
   {{ $key }}: {{ $val | quote }}
   {{- end }}
+  {{- if .Values.databaseConnection.jdbcUrl }}
+  ATL_JDBC_URL: "{{ .Values.databaseConnection.jdbcUrl }}"
+  {{- else }}
   ATL_JDBC_URL: "jdbc:{{ .Values.databaseConnection.type }}://{{ .Values.databaseConnection.host }}:{{ .Values.databaseConnection.port }}/{{ .Values.databaseConnection.database }}"
+  {{- end }}
   ATL_JDBC_USER: "{{ .Values.databaseConnection.user }}"
   ATL_DB_TYPE: "{{ .Values.databaseConnection.type }}"
   {{- if .Values.ingress.enabled }}

--- a/charts/confluence-server/values.yaml
+++ b/charts/confluence-server/values.yaml
@@ -275,6 +275,9 @@ databaseConnection:
   ## Database Type
   type: postgresql
 
+  ## Database JDBC URL (optional: override for types other than postgresql)
+  # jdbcUrl: jdbc:sqlserver://sql.server.host:1234;database=mydb;user=myuser;password=mypassword
+
 ## DB DROP, use with caution!
 ## If postgresql.enabled is set to true and database exists, it will drop the db before creating a new one
 ## (see db-helper ConfigMap)


### PR DESCRIPTION
Hi @javimox, as discusssed, this PR allows for the override of the JDBC URL, for instance when using SQL Server as the backing database.