### PR TITLE
feat(confluence-server): support custom pod labels

### DIFF
--- a/charts/confluence-server/Chart.yaml
+++ b/charts/confluence-server/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.0.0
+version: 3.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/confluence-server/README.md
+++ b/charts/confluence-server/README.md
@@ -178,6 +178,7 @@ By default a PostgreSQL will be deployed and a user and a database will be creat
 | `tolerations`                        | List of node taints to tolerate                                                           | `[]`                          |
 | `affinity`                           | Map of node/pod affinity labels                                                           | `{}`                          |
 | `podAnnotations`                     | Map of annotations to add to the pods                                                     | `{}`                          |
+| `podLabels`                          | Map of labels to add to the pods                                                          | `{}`                          |
 | `extraVolumeMounts`                  | Additional volume mounts to add to the pods                                               | `[]`                          |
 | `extraVolumes`                       | Additional volumes to add to the pods                                                     | `[]`                          |
 | `schedulerName`                      | Use an alternate scheduler, eg. `stork`                                                   | `""`                          |

--- a/charts/confluence-server/templates/deployment.yaml
+++ b/charts/confluence-server/templates/deployment.yaml
@@ -15,6 +15,9 @@ spec:
     metadata:
       labels:
         {{- include "confluence-server.selectorLabels" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+          {{- toYaml .Values.podLabels | nindent 8 }}
+        {{- end }}
       {{- with .Values.podAnnotations }}
       annotations:
         {{- . | toYaml | trim | nindent 8 }}

--- a/charts/confluence-server/values.yaml
+++ b/charts/confluence-server/values.yaml
@@ -125,6 +125,10 @@ affinity: {}
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 podAnnotations: {}
 
+## Pod labels
+## red: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
 ## Persistent Volume Claim
 ## Confluence Home directory
 ## https://kubernetes.io/docs/concepts/storage/persistent-volumes/


### PR DESCRIPTION
##### SUMMARY
Support custom pod labels

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
confluence-server Helm chart

#### Describe the change
This merge adds the `.Value.podLabels` parameter to the confluence-server Helm chart.