### PR TITLE
feat(confluence): add pod priority support

### DIFF
--- a/charts/confluence-server/Chart.yaml
+++ b/charts/confluence-server/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.1.0
+version: 3.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/confluence-server/README.md
+++ b/charts/confluence-server/README.md
@@ -177,6 +177,7 @@ By default a PostgreSQL will be deployed and a user and a database will be creat
 | `nodeSelector`                       | Node labels for pod assignment                                                            | `{}`                          |
 | `tolerations`                        | List of node taints to tolerate                                                           | `[]`                          |
 | `affinity`                           | Map of node/pod affinity labels                                                           | `{}`                          |
+| `priorityClassName`                  | Pod priority class name                                                                   | `nil`                         |
 | `podAnnotations`                     | Map of annotations to add to the pods                                                     | `{}`                          |
 | `podLabels`                          | Map of labels to add to the pods                                                          | `{}`                          |
 | `extraVolumeMounts`                  | Additional volume mounts to add to the pods                                               | `[]`                          |

--- a/charts/confluence-server/templates/deployment.yaml
+++ b/charts/confluence-server/templates/deployment.yaml
@@ -151,3 +151,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName  }}
+      {{- end }}

--- a/charts/confluence-server/values.yaml
+++ b/charts/confluence-server/values.yaml
@@ -121,6 +121,10 @@ tolerations: []
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}
 
+## Priority Class for pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+priorityClassName: ""
+
 ## Pod annotations
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 podAnnotations: {}


### PR DESCRIPTION
##### SUMMARY
Support  pod priority

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
confluence-server Helm chart

#### Describe the change
This merge adds the `.Value.priorityClassName` parameter to the confluence-server Helm chart.
Pods can have priority. Priority indicates the importance of a Pod relative to other Pods. If a Pod cannot be scheduled, the scheduler tries to preempt (evict) lower priority Pods to make scheduling of the pending Pod possible.