### PR TITLE
Update Ingress-Template for Confluence and Jira chart to current Kubernetes standards

### DIFF
--- a/charts/confluence-server/Chart.yaml
+++ b/charts/confluence-server/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.2.0
+version: 3.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/confluence-server/templates/ingress.yaml
+++ b/charts/confluence-server/templates/ingress.yaml
@@ -18,6 +18,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+{{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- end }}
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}

--- a/charts/confluence-server/templates/ingress.yaml
+++ b/charts/confluence-server/templates/ingress.yaml
@@ -1,6 +1,9 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "confluence-server.fullname" . -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- $ingressApiV1 := semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if $ingressApiV1 -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -32,9 +35,19 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            {{- if  $ingressApiV1 }}
+            pathType: ImplementationSpecific
+            {{- end }}
             backend:
+              {{- if $ingressApiV1 }}
+              service:
+                name: {{ $fullName }}
+                port: 
+                  number: 80
+              {{- else }}
               serviceName: {{ $fullName }}
               servicePort: 80
+              {{- end }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/confluence-server/values.yaml
+++ b/charts/confluence-server/values.yaml
@@ -85,6 +85,7 @@ ingress:
   ## Set to true to enable ingress record generation
   enabled: false
   annotations: {}
+  ingressClassName: ''
   # kubernetes.io/ingress.class: nginx
   # kubernetes.io/tls-acme: "true"
   hosts:

--- a/charts/jira-software/Chart.yaml
+++ b/charts/jira-software/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.2.2
+version: 2.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/jira-software/templates/ingress.yaml
+++ b/charts/jira-software/templates/ingress.yaml
@@ -18,6 +18,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+{{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- end }}
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}

--- a/charts/jira-software/templates/ingress.yaml
+++ b/charts/jira-software/templates/ingress.yaml
@@ -1,6 +1,9 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "jira-software.fullname" . -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- $ingressApiV1 := semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if $ingressApiV1 -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -32,9 +35,19 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            {{- if  $ingressApiV1 }}
+            pathType: ImplementationSpecific
+            {{- end }}
             backend:
+              {{- if $ingressApiV1 }}
+              service:
+                name: {{ $fullName }}
+                port: 
+                  number: 80
+              {{- else }}
               serviceName: {{ $fullName }}
               servicePort: 80
+              {{- end }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/jira-software/values.yaml
+++ b/charts/jira-software/values.yaml
@@ -85,6 +85,7 @@ ingress:
   ## Set to true to enable ingress record generation
   enabled: false
   annotations: {}
+  ingressClassName: ''
   # kubernetes.io/ingress.class: nginx
   # kubernetes.io/tls-acme: "true"
   hosts:


### PR DESCRIPTION
Added support for Kubernetes Ingress API v1 and ingressClassName as mentioned in [#70](https://github.com/javimox/helm-charts/issues/70). 
I only tested it with the Jira Chart since I don't have a confluence deployment running but the changes are the same, so I don't miage there'll be any problems. 

I set pathType to "ImplementationSpecific" because giving the user the option to change it via values.yaml would have required a breaking change in the paths loop and I didn't want to break backwards compatibilty. 

Let me know if there's any issues or questions. 