### PR TITLE
[confluence-server] Add possibility to define hostAliases

### DIFF
--- a/charts/confluence-server/Chart.yaml
+++ b/charts/confluence-server/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.3.0
+version: 3.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/confluence-server/Chart.yaml
+++ b/charts/confluence-server/Chart.yaml
@@ -8,17 +8,17 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.3.1
+version: 3.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 7.9.3
+appVersion: 8.5.0
 
 icon: https://mox.sh/assets/images/confluence-logo.png
 
 dependencies:
   - name: postgresql
-    version: 9.1
+    version: 12.x.x
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
     tags:

--- a/charts/confluence-server/README.md
+++ b/charts/confluence-server/README.md
@@ -173,6 +173,7 @@ By default a PostgreSQL will be deployed and a user and a database will be creat
 |--------------------------------------|-------------------------------------------------------------------------------------------|-------------------------------|
 | `replicaCount`                       | Number of replicas for this deployment                                                    | `1`                           |
 | `securityContext`                    | Container security context options                                                        | `{}`                          |
+| `hostAliases`                        | Host aliases that are added to the pods                                                   | `[]`                          |
 | `resources`                          | CPU/Memory resource requests/limits                                                       | Memory: `1Gi`, CPU: `500m`    |
 | `nodeSelector`                       | Node labels for pod assignment                                                            | `{}`                          |
 | `tolerations`                        | List of node taints to tolerate                                                           | `[]`                          |

--- a/charts/confluence-server/README.md
+++ b/charts/confluence-server/README.md
@@ -357,7 +357,7 @@ $ helm upgrade --install my-release \
 
 ## <a name="values_values-prod-diff"></a>Difference between values and values-production
 
-Chart Version 2.0.5
+Chart Version 3.7.0
 ```diff
 --- confluence-server/values.yaml
 +++ confluence-server/values-production.yaml

--- a/charts/confluence-server/templates/deployment.yaml
+++ b/charts/confluence-server/templates/deployment.yaml
@@ -69,6 +69,8 @@ spec:
       serviceAccountName: {{ include "confluence-server.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      hostAliases:
+        {{- toYaml .Values.hostAliases | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           {{- if .Values.securityContext }}

--- a/charts/confluence-server/values-production.yaml
+++ b/charts/confluence-server/values-production.yaml
@@ -45,6 +45,13 @@ serviceAccount:
 podSecurityContext:
   fsGroup: 2002
 
+# Mapping between IP and hostnames that will be injected as entries in the pod's hosts files
+## ref: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/
+hostAliases: []
+  # - ip: 10.20.30.40
+  #   hostnames:
+  #   - git.myhostname
+
 ## Security context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 securityContext: {}

--- a/charts/confluence-server/values-production.yaml
+++ b/charts/confluence-server/values-production.yaml
@@ -12,7 +12,7 @@
 image:
   # registry: hub.docker.com
   repository: atlassian/confluence-server
-  tag: 7.9.3
+  tag: 8.5.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/charts/confluence-server/values.yaml
+++ b/charts/confluence-server/values.yaml
@@ -45,6 +45,13 @@ serviceAccount:
 podSecurityContext:
   fsGroup: 2002
 
+# Mapping between IP and hostnames that will be injected as entries in the pod's hosts files
+## ref: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/
+hostAliases: []
+  # - ip: 10.20.30.40
+  #   hostnames:
+  #   - git.myhostname
+
 ## Security context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 securityContext: {}

--- a/charts/confluence-server/values.yaml
+++ b/charts/confluence-server/values.yaml
@@ -12,7 +12,7 @@
 image:
   # registry: hub.docker.com
   repository: atlassian/confluence-server
-  tag: 7.9.3
+  tag: 8.5.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Hi, I would like to have the ability to add `hostAliases` in the confluence-server helm chart and this PR implements exactly this feature. Hope I am not missing something. Thanks!
