### PR TITLE
Avoid env variables conflinct in case of external SSL termination

### DIFF
--- a/charts/jira-software/Chart.yaml
+++ b/charts/jira-software/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.4.7
+version: 2.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
@@ -18,8 +18,8 @@ icon: https://mox.sh/assets/images/jira-logo.png
 
 dependencies:
   - name: postgresql
-    version: 9.1
-    repository: https://charts.bitnami.com/bitnami
+    version: 12.x.x
+    repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled
     tags:
       - postgres

--- a/charts/jira-software/templates/configmap.yaml
+++ b/charts/jira-software/templates/configmap.yaml
@@ -14,8 +14,16 @@ data:
   ATL_DB_TYPE: "{{ .Values.databaseConnection.type }}"
   ATL_DB_SCHEMA_NAME: "{{ .Values.databaseConnection.schemaName }}"
   {{- if .Values.ingress.enabled }}
+    {{- if not .Values.envVars.ATL_PROXY_NAME }}
   ATL_PROXY_NAME: {{ (index .Values.ingress.hosts 0).host | quote }}
+    {{- end }}
+    {{- if not .Values.envVars.ATL_PROXY_PORT }}
   ATL_PROXY_PORT: {{ if .Values.ingress.tls }}"443"{{ else }}"80"{{ end }}
+    {{- end }}
+    {{- if not .Values.envVars.ATL_TOMCAT_SCHEME }}
   ATL_TOMCAT_SCHEME: {{ if .Values.ingress.tls }}"https"{{ else }}"http"{{ end }}
+    {{- end }}
+    {{- if not .Values.envVars.ATL_TOMCAT_SECURE }}
   ATL_TOMCAT_SECURE: {{ if .Values.ingress.tls }}"true"{{ else }}"false"{{ end }}
+    {{- end }}
   {{- end }}


### PR DESCRIPTION
If you are using external LB with SSL terminations which is passing only plain HTTP requests to ingress you have to pass 
ATL_PROXY_NAME, ATL_PROXY_PORT, ATL_TOMCAT_SCHEME & ATL_TOMCAT_SECURE variables without passing ingress tls options.