### PR TITLE
Allow to define resources for init containers

### DIFF
--- a/charts/confluence-server/templates/deployment.yaml
+++ b/charts/confluence-server/templates/deployment.yaml
@@ -33,6 +33,8 @@ spec:
             "sh",
             "-c",
             "until pg_isready -h {{ .Values.postgresql.fullnameOverride }} -p 5432 ; do echo waiting for {{ .Values.postgresql.fullnameOverride }}; sleep 5; done;"]
+          resources:
+            {{- toYaml .Values.postgresql.initdbResources | nindent 12 }}
         {{- end }}
         {{- if .Values.caCerts }}
         - name: ca-certs
@@ -53,6 +55,8 @@ spec:
               name: {{ include "confluence-server.pvcHome" . }}
             - mountPath: /var/atlassian/application-data/confluence/secrets/cas
               name: confluence-cas
+          resources:
+            {{- toYaml .Values.caCerts.resources | nindent 12 }}
           {{- with .Values.caCertsEnv }}
           env:
             {{- . | toYaml | trim | nindent 12 }}

--- a/charts/confluence-server/values.yaml
+++ b/charts/confluence-server/values.yaml
@@ -254,6 +254,9 @@ postgresql:
   initdbScriptsConfigMap: |-
     {{ .Release.Name }}-db-helper-cm
 
+  ## InitDB container resources
+  initdbResources: {}
+
   ## Use existing secret to set the password for 'databaseConnection.user' in postgres
   ## https://github.com/javimox/helm-charts/tree/master/charts/confluence-server#use-existing-secrets
   ## https://github.com/bitnami/charts/tree/master/bitnami/postgresql#initialize-a-fresh-instance
@@ -310,6 +313,7 @@ databaseDrop:
 caCerts: {}
   # secret: my-secret
   # storepass: my-store-password
+  # resources: {}
 # caCertsEnv:
 #   - name: VARIABLE
 #     value: my-value

--- a/charts/jira-software/templates/deployment.yaml
+++ b/charts/jira-software/templates/deployment.yaml
@@ -30,6 +30,10 @@ spec:
             "sh",
             "-c",
             "until pg_isready -h {{ .Values.postgresql.fullnameOverride }} -p 5432 ; do echo waiting for {{ .Values.postgresql.fullnameOverride }}; sleep 5; done;"]
+          {{- with .Values.postgresql.initdbResources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- end }}
         {{- if .Values.caCerts }}
         - name: ca-certs
@@ -53,6 +57,10 @@ spec:
           {{- with .Values.caCertsEnv }}
           env:
             {{- . | toYaml | trim | nindent 12 }}
+          {{- end }}
+          {{- with .Values.caCerts.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- end }}
       {{- end }}

--- a/charts/jira-software/values.yaml
+++ b/charts/jira-software/values.yaml
@@ -229,6 +229,9 @@ postgresql:
   initdbScriptsConfigMap: |-
     {{ .Release.Name }}-db-helper-cm
 
+  ## InitDB container resources
+  initdbResources: {}
+
   ## Use existing secret to set the password for 'databaseConnection.user' in postgres
   ## https://github.com/javimox/helm-charts/tree/master/charts/jira-software#use-existing-secrets
   ## https://github.com/bitnami/charts/tree/master/bitnami/postgresql#initialize-a-fresh-instance
@@ -303,6 +306,7 @@ databaseDrop:
 caCerts: {}
   # secret: my-secret
   # storepass: my-store-password
+  # resources: {}
 # caCertsEnv:
 #   - name: VARIABLE
 #     value: my-value


### PR DESCRIPTION
Problem: I have resourcequotas defined on namespaces in my k8s cluster. Jira & Confluence deployments fails due to missing resource limits for init containers.

Solution: provide an ability to define init containers resources.